### PR TITLE
Fixes crash when architecture for a given image was not found

### DIFF
--- a/dockersave/__init__.py
+++ b/dockersave/__init__.py
@@ -4,6 +4,7 @@ import requests, os, json, hashlib, tarfile, shutil, subprocess
 from os.path import join, exists
 from requests.auth import HTTPBasicAuth
 from dockersave.exceptions import UnsupportedManifest
+from sys import exit as sys_exit
 import time
 
 json_template = {
@@ -80,12 +81,16 @@ def get_manifest(image, tag, token, registry_url, arch="amd64"):
             )
 
     if r.headers["content-type"] in supported_fat_manifests:
-        return get_manifest(
-                image, 
-                next(x['digest'] for x in r.json()['manifests'] if x['platform']['architecture'] == arch), 
-                token, 
-                registry_url
-                )
+        try:
+            return get_manifest(
+                    image, 
+                    next(x['digest'] for x in r.json()['manifests'] if x['platform']['architecture'] == arch), 
+                    token, 
+                    registry_url
+                    )
+        except StopIteration:
+            print(f"arch {arch} not found")
+            sys_exit(1)
 
     r.raise_for_status()
     return r

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 setuptools.setup(
-        name="dockersave",
+        name="docker-image-save",
         version="0.1",
         author="Adam Olech",
         author_email="aolech@antmicro.com",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import setuptools
 
 setuptools.setup(
-        name="docker-image-save",
+        name="dockersave",
         version="0.1",
         author="Adam Olech",
         author_email="aolech@antmicro.com",


### PR DESCRIPTION
**Problem**: When trying to download the image with the architecture that is not available, the program crashes.

For command:  `./dockersave-static --arch riscv64 debian`
Result: 
```
Traceback (most recent call last):
  File "dockersave/cli.py", line 89, in <module>
    main()
  File "dockersave/cli.py", line 86, in main
    args.func(args)
  File "dockersave/cli.py", line 29, in download
    img = Image(
  File "dockersave/__init__.py", line 207, in __init__
    self.manifest_response = get_manifest(image, tag, self.token, self.registry_url, arch)
  File "dockersave/__init__.py", line 85, in get_manifest
    next(x['digest'] for x in r.json()['manifests'] if x['platform']['architecture'] == arch), 
StopIteration
[640752] Failed to execute script 'cli' due to unhandled exception!
```

Solution: Catch the exception and print a message:

```
$ ./dockersave-static --arch riscv64 debian

> arch riscv64 not found
```